### PR TITLE
routes.rb修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root 'users#index'
   get "signup", to: "signup#index"
   resources :products, only: [:show]
-  resources :users, only: [:index, :edit, :update]
+  resources :users
   resources :signup, only: [:new]do
     collection do
       get 'step1'


### PR DESCRIPTION
#what
routes.rbのresources:usersのonly以下を削除

#why
usersコントローラーの全てのアクションを読み込ませるため